### PR TITLE
Specify scheme in library.properties url value

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,6 +5,6 @@ maintainer=Alessio Leoncini
 sentence=A library providing the possibility to call a function at specific time intervals. 
 paragraph=Present library defines a 'EveryTimer' class that allows to call a user defined function every time a timeout occurs. In addition, a similar 'OneShotTimer' allows one to call a oser defined function one single time after a specified timeout.
 category=Timing
-url=technologytourist.com
+url=https://technologytourist.com
 architectures=*
 includes=EveryTimer.h, OneShotTimer.h


### PR DESCRIPTION
The library.properties `url` property is used by the Arduino IDE to add a clickable "More info" link to the Library Manager entry for each library. The scheme must be specified in order for this link to be clickable.